### PR TITLE
Fetch all organization repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Data structures that may be generally useful
 ## Program Analysis
 
 - [build-bom](https://github.com/travitch/build-bom) [26 :star:]: Dynamically discover the commands used to create a piece of software
-- [whole-program-llvm](https://github.com/travitch/whole-program-llvm) [507 :star:]: A wrapper script to build whole-program LLVM bitcode files; note that I consider this to be obsoleted by `build-bom`, which takes a more robust approach to the same problem
+- [whole-program-llvm](https://github.com/travitch/whole-program-llvm) [508 :star:]: A wrapper script to build whole-program LLVM bitcode files; note that I consider this to be obsoleted by `build-bom`, which takes a more robust approach to the same problem
 - [itanium-abi](https://github.com/travitch/itanium-abi) [10 :star: [:book:](https://hackage.haskell.org/package/itanium-abi)]: An implementation of C++ name mangling for the Itanium ABI
 - [what4-serialize](https://github.com/GaloisInc/what4-serialize) [0 :star:]: Serialization/deserialization for What4 expressions
 
@@ -51,7 +51,7 @@ Note that these are interesting and informative, but definitely not efficient en
 
 ## Others
 
-- [taffybar](https://github.com/taffybar/taffybar) [606 :star: [:book:](https://hackage.haskell.org/package/taffybar)]: A gtk based status bar for tiling window managers such as XMonad; now maintained by Ivan Malison
+- [taffybar](https://github.com/taffybar/taffybar) [607 :star: [:book:](https://hackage.haskell.org/package/taffybar)]: A gtk based status bar for tiling window managers such as XMonad; now maintained by Ivan Malison
 - [travitch](https://github.com/travitch/travitch) [1 :star:]: The code for my Github profile page, which generates this page
 - [blog](https://github.com/travitch/blog) [3 :star:]: The code for my blog (ravit.ch)
 - [dotfiles](https://github.com/travitch/dotfiles) [0 :star:]: A collection of dotfiles managed by Chezmoi

--- a/data/query.graphql
+++ b/data/query.graphql
@@ -14,10 +14,11 @@ query MyRepositoriesQuery {
     }
     name
     updatedAt
-    url    
+    url
   }
-  organization(login: "GaloisInc") {
-    repositories(isFork: false, privacy: PUBLIC, first: 100, orderBy: { field:UPDATED_AT, direction: DESC}) {
+	user(login: "travitch") {
+    name
+    repositories(isFork: false, first: 100) {
       edges {
         node {
           id
@@ -37,17 +38,23 @@ query MyRepositoriesQuery {
           url
         }
       }
-    }    
-  }
-	user(login: "travitch") {
-    name
-    repositories(isFork: false, first: 100) {
+    }
+	}
+}
+
+query GaloisRepositoriesQuery($token : String) {
+  organization(login: "GaloisInc") {
+    repositories(isFork: false, privacy: PUBLIC, first: 100, after: $token, orderBy: { field:UPDATED_AT, direction: DESC}) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
       edges {
         node {
           id
           createdAt
           description
-          forkCount 
+          forkCount
           stargazerCount
           languages(first: 5) {
             edges {
@@ -62,5 +69,5 @@ query MyRepositoriesQuery {
         }
       }
     }
-	}
+  }
 }


### PR DESCRIPTION
Github imposes a limit of 100 repositories per query. Some of the records I needed fell out of the first 100, so this commit changes the graphql query to fetch all repositories using the pagination mechanism.